### PR TITLE
Enhance encrypt: add --output, --device args and LUKS verification

### DIFF
--- a/kms-encrypt.rb
+++ b/kms-encrypt.rb
@@ -7,9 +7,45 @@ require 'openssl'
 require 'aws-sdk-kms'
 require 'base64'
 require 'json'
+require 'optparse'
+
+options = {}
+OptionParser.new do |opts|
+  opts.banner = 'Usage: kms-encrypt.rb [options] INPUTFILE'
+
+  opts.on('--output FILE', 'Write JSON output to FILE') do |f|
+    options[:output] = f
+  end
+
+  opts.on('--device DEVICE', 'LUKS device path to verify') do |d|
+    options[:device] = d
+  end
+
+  opts.on('-h', '--help', 'Show this help') do
+    puts opts
+    exit
+  end
+end.parse!
 
 if ARGV[0].nil?
-  puts 'Usage: encrypt.rb INPUTFILE'
+  puts 'Usage: kms-encrypt.rb [options] INPUTFILE'
+  exit 1
+end
+
+if options[:device].nil?
+  puts 'Error: --device is required'
+  exit 1
+end
+
+if options[:output].nil?
+  puts 'Error: --output is required'
+  exit 1
+end
+
+# Verify the device is a LUKS volume
+cryptsetup_result = system('cryptsetup', '--batch-mode', 'isLuks', options[:device])
+unless cryptsetup_result
+  puts "Error: #{options[:device]} is not a LUKS device (cryptsetup isLuks returned non-zero)"
   exit 1
 end
 
@@ -41,9 +77,13 @@ cipher = aes.update(plaintext)
 cipher << aes.final
 
 cipher64 = Base64.strict_encode64(cipher)
-outputhash = { 'ciphertext' => cipher64,
+outputhash = { 'device' => options[:device],
+               'ciphertext' => cipher64,
                'iv' => Base64.strict_encode64(iv),
                'datakey' => Base64.strict_encode64(
                  kmsresponse.ciphertext_blob
                ) }
-puts JSON.pretty_generate(outputhash)
+
+json_output = JSON.pretty_generate(outputhash)
+File.write(options[:output], json_output)
+puts "Encrypted output written to #{options[:output]}"


### PR DESCRIPTION
Implements #416

- Add --output FILE argument to write JSON output to a file
- Add --device DEVICE argument for LUKS device path
- Validate device is a LUKS volume using cryptsetup --batch-mode isLuks
- Include device name in JSON output (unencrypted)
- Abort with error if cryptsetup returns non-zero exit code

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added required `--device` and `--output` command-line arguments for device path and output file specification
  * Added device validation step before encryption processing
  * Modified output to write JSON to specified file with confirmation message

* **Documentation**
  * Updated help/usage text references

<!-- end of auto-generated comment: release notes by coderabbit.ai -->